### PR TITLE
Fix location of data file finder

### DIFF
--- a/ping_me/authenticate.py
+++ b/ping_me/authenticate.py
@@ -9,6 +9,7 @@ import sys
 
 import phonenumbers
 import ping_me
+from ping_me.data import module_locator
 
 home = os.path.expanduser("~")
 
@@ -98,10 +99,8 @@ def newuser():
 
     code_to_country = {}
     # Location of the csv file is ambiguous
-    try:
-        csvfile = open("data/countrylist.csv")
-    except:
-        csvfile = open("ping_me/data/countrylist.csv")
+    csv_path = module_locator.modeule_path()
+    csvfile = open(csv_path + "/countrylist.csv")
     reader = csv.DictReader(csvfile)
     for row in reader:
         code_to_country[row["ITU-T Telephone Code"]] = row["Common Name"]

--- a/ping_me/data/module_locator.py
+++ b/ping_me/data/module_locator.py
@@ -1,0 +1,13 @@
+"""Locate the data files in the eggs to open"""
+
+import os
+import sys
+
+def we_are_forzen():
+    return hasattr(sys, "frozen")
+
+def modeule_path():
+    encoding = sys.getfilesystemencoding()
+    if we_are_forzen():
+        return os.path.dirname(unicode(sys.executable, encoding))
+    return os.path.dirname(unicode(__file__, encoding))

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         author_email = 'himanshumishra@iitkgp.ac.in',
         description = 'Cross platform personalized ping',
         long_description = open('README.md').read(),
-        packages = ['ping_me', 'ping_me.depends'],
+        packages = ['ping_me', 'ping_me.depends', 'ping_me.data'],
         data_files = [('ping_me/data', ['ping_me/data/countrylist.csv'])],
         license = 'Apache License',
         entry_points = {


### PR DESCRIPTION
This was tricky. The normal `open()` reads the file location relative to where it is called from. But in cases we need to open a file relative to the location of the module, we can use the the trick of using the location of `__file__`. It surely won't work from interpreters.
