### PR TITLE
Use crontab instead of ad-hoc `nohup`

### DIFF
--- a/ping_me/GET.py
+++ b/ping_me/GET.py
@@ -5,40 +5,31 @@ import ast
 import requests
 import sys
 import subprocess
-import time
 
 from ping_me.utils import cryptex
 import ping_me.authenticate
 
 def main():
-    while(True):
-        target = "http://ping-me.himanshumishra.in/ping/"
-        email = ping_me.authenticate.extract_email()
-        key = ping_me.authenticate.extract_password()
-        data_t = {
-            "email" : email,
-            "password" : key
-        }
-        try:
-            r = requests.post(target, data=data_t)
-            if ast.literal_eval(r.text)["success"] == "True":
-                message = cryptex.decryptor(key, ast.literal_eval(r.text)["message"])
-                # Recieved the ping 5 seconds earlier
-                time.sleep(5)
-                if sys.platform == 'linux2':
-                    subprocess.call(['notify-send', message])
-                elif sys.platform == 'darwin':
-                    # Need to install `terminal-notifier`
-                    # $ brew install terminal-notifier
-                    subprocess.call(['terminal-notifier', '-title',
-                                     'ping-me', message])
-                elif sys.platform in ['win32', 'win64']:
-                    # Do things for windows
-                    pass
-            else:
-                time.sleep(1)
-        except Exception as e:
-            print(e)
+    target = "http://ping-me.himanshumishra.in/ping/"
+    email = ping_me.authenticate.extract_email()
+    key = ping_me.authenticate.extract_password()
+    data_t = {
+        "email" : email,
+        "password" : key
+    }
+    r = requests.post(target, data=data_t)
+    if ast.literal_eval(r.text)["success"] == "True":
+        message = cryptex.decryptor(key, ast.literal_eval(r.text)["message"])
+        if sys.platform == 'linux2':
+            subprocess.call(['notify-send', message])
+        elif sys.platform == 'darwin':
+            # Need to install `terminal-notifier`
+            # $ brew install terminal-notifier
+            subprocess.call(['terminal-notifier', '-title',
+                             'ping-me', message])
+        elif sys.platform in ['win32', 'win64']:
+            # Do things for windows
+            pass
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
So, after some really great time spent in understanding the procedure, we're finally using crontab ! It's smooth and easy to use.

Usage instructions :
1. Install : 
   `$ pip install ping-me`
2. Edit crontab file :
   `$ crontab -e`
3. Add the following 3 lines

```
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
DISPLAY=:0.0

* * * * * get-ping
```
1. Save and exit. That's it :)
## 

Some explanation :
1. cron actually does not have all the paths in its `$PATH` variable. Hence we need to add custom locations in the PATH variable.
2. Each host can have multiple displays, and each display can have multiple screens. Hence we need to specify the screen used by `notify-send`. (This one took a lot of debugging)
3. The `get-ping` script searches for a ping in the next minute.
